### PR TITLE
feat : 기부처 리스트에서 상세 페이지로 라우팅 구현

### DIFF
--- a/src/frontend/src/app/donation/list/page.tsx
+++ b/src/frontend/src/app/donation/list/page.tsx
@@ -10,13 +10,13 @@ export default function DonationListPage() {
 
   const donationItems = [
     {
-      id: 'wildfire',
+      id: 'firevictims',
       title: '산불 이재민 기부',
       subtitle: '구호 성금 전달',
       image: '/donation_wildfire.jpg',
     },
     {
-      id: 'firehospital',
+      id: 'firefighter',
       title: '국립소방병원 기부',
       subtitle: '(주) 수방가족희망나눔',
       image: '/donation_firehospital.jpg',
@@ -82,7 +82,7 @@ export default function DonationListPage() {
 
               {/* 상세보기 버튼 */}
               <button
-                onClick={() => router.push(`/donation/list/${item.id}`)}
+                onClick={() => router.push(`/donation/detail/${item.id}`)}
                 className="ml-2 bg-yellow-400 text-white text-xs sm:text-sm px-3 py-1 sm:px-4 sm:py-1.5 rounded-full whitespace-nowrap"
               >
                 상세보기


### PR DESCRIPTION
## 개요
기부처 리스트 페이지(`/donation/list`)에서 각 기부처의 상세페이지(`/donation/detail/[id]`)로 라우팅되도록 기능을 추가했습니다.

## 주요 변경 사항
- `donationItems`의 `id` 값을 기반으로 각 기부처의 고유 경로 생성
- 상세보기 버튼 클릭 시 `router.push('/donation/detail/[id]')`를 통해 해당 상세 페이지로 이동
- 기존 라우팅 경로 `/donation/list/[id]` → `/donation/detail/[id]`로 수정

## 폴더 구조 반영