### PR TITLE
feat : useSearchParams() 관련 빌드 오류 해결

### DIFF
--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -1,5 +1,3 @@
-@import "tailwindcss";
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/frontend/src/app/review/page.tsx
+++ b/src/frontend/src/app/review/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, Suspense } from 'react' // Suspense 추가
 import Image from 'next/image'
 import { useRouter, useSearchParams} from 'next/navigation'
 import { FaStar } from 'react-icons/fa'
@@ -18,7 +18,8 @@ interface Store {
   // ...필요 필드
 }
 
-export default function WriteReviewPage() {
+// 기존 WriteReviewPage 내용을 새 컴포넌트로 이동
+function ClientReviewPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams();
   const businessNumber = searchParams.get('bno');
@@ -28,7 +29,7 @@ export default function WriteReviewPage() {
   const [hoverRating, setHoverRating] = useState(0)
   const [review, setReview] = useState('')
   const [isModalOpen, setIsModalOpen] = useState(false)
-  
+
   // 사업자번호로 가게정보 패칭
   useEffect(() => {
     if (!businessNumber) return;
@@ -167,7 +168,7 @@ export default function WriteReviewPage() {
           </div>
         </div>
       </main>
-      
+
       {/* ✅ 하단탭 */}
       <BottomTab />
 
@@ -178,4 +179,13 @@ export default function WriteReviewPage() {
         }} />
     </>
   )
+}
+
+// Suspense로 감싸서 export
+export default function WriteReviewPage() {
+    return (
+        <Suspense fallback={<div>페이지를 로딩 중입니다...</div>}> {/* fallback은 로딩 중 표시될 내용 */}
+            <ClientReviewPageContent />
+        </Suspense>
+    )
 }

--- a/src/frontend/src/app/submit_store/page.tsx
+++ b/src/frontend/src/app/submit_store/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, Suspense } from 'react' // Suspense 추가
 import { useRouter } from 'next/navigation'
 import PointModal from '@/components/modals/PointModal'
 import Header from '@/components/Header'
@@ -8,8 +8,8 @@ import BottomTab from '@/components/BottomTab'
 import { useSearchParams } from 'next/navigation';
 
 
-
-export default function VerifyPage() {
+// 기존 VerifyPage 내용을 ClientVerifyPageContent 함수로 이동
+function ClientVerifyPageContent() {
   const router = useRouter()
   const [category, setCategory] = useState('')
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -31,10 +31,10 @@ export default function VerifyPage() {
 
   const payload = {
     businessNumber, // 사업자 번호
-    storeName,    // 가게 이름
-    category,     // 업종
-    reason,       // 돈쭐 이유
-    review        // 소비 후기
+    storeName,      // 가게 이름
+    category,       // 업종
+    reason,         // 돈쭐 이유
+    review          // 소비 후기
   };
   console.log('payload:', payload);
 
@@ -135,8 +135,6 @@ export default function VerifyPage() {
                 </span>
               </span>
 
-              
-
               <textarea
                 placeholder="사장님의 어떤 선행이 기억에 남았나요?"
                 maxLength={500}
@@ -158,7 +156,7 @@ export default function VerifyPage() {
                 onChange={(e) => setReview(e.target.value)}
               />
             </div>
-             {/* 하단 버튼 */}
+               {/* 하단 버튼 */}
             <div className="mt-15">
               <button
                 onClick={handleSubmit}
@@ -169,15 +167,14 @@ export default function VerifyPage() {
           </button>
           </div>
           </div> {/* ✅ 입력폼 전체 div 닫음 */}
-        </div> {/* ✅ 바깥 카드 div 닫음 (기존 누락됐던 부분) */}
+        </div> {/* ✅ 바깥 카드 div 닫음 */}
 
-       
 
         <BottomTab />
 
         {/* 모달 */}
         <PointModal
-          isOpen={isModalOpen} 
+          isOpen={isModalOpen}
           onClose={() => {
             setIsModalOpen(false);
             router.push('/main');
@@ -185,4 +182,13 @@ export default function VerifyPage() {
       </main>
     </>
   )
+}
+
+// Suspense로 감싸서 export default
+export default function VerifyPage() {
+    return (
+        <Suspense fallback={<div>페이지를 로딩 중입니다...</div>}> {/* 로딩 중 표시될 내용 */}
+            <ClientVerifyPageContent />
+        </Suspense>
+    )
 }

--- a/src/frontend/tailwind.confg.js
+++ b/src/frontend/tailwind.confg.js
@@ -1,6 +1,12 @@
+// tailwind.config.js
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}', // App Router 사용 시
+    './src/**/*.{js,ts,jsx,tsx,mdx}', // src 디렉토리 전체를 포함하는 것이 안전
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
< 상세 내용 > 
기존에 /review 및 /submit_store 페이지는 useSearchParams() 훅을 사용하여 URL 쿼리 파라미터를 읽어들이고 있었습니다. 
이 페이지들은 app router의 클라이언트 컴포넌트로 명시("use client")되어 있었음에도 불구하고, next build 과정 중 정적 사전 렌더링(prerendering) 단계에서 서버 환경이 useSearchParams() 훅을 처리할 수 없어 빌드 실패로 이어지는 문제가 발생했습니다.

이는 Next.js의 next export (정적 사이트 생성) 동작과 클라이언트 전용 훅의 상호작용 때문에 발생하는 특정 이슈입니다.
Next.js 공식 문서에 따르면, next export를 통해 useSearchParams()를 사용하는 애플리케이션을 정적 빌드하려면 해당 컴포넌트를 반드시 <Suspense> 바운더리로 감싸야 합니다.

<적용된 해결책>

1) src/app/review/page.tsx:

기존 WriteReviewPage 컴포넌트의 로직을 ClientReviewPageContent라는 새로운 컴포넌트로 이동했습니다.
export default 하는 WriteReviewPage 컴포넌트에서 ClientReviewPageContent를 <Suspense fallback={<div>페이지를 로딩 중입니다...</div>}>로 감싸도록 수정했습니다.

2) src/app/submit_store/page.tsx:

마찬가지로, 기존 VerifyPage 컴포넌트의 로직을 ClientVerifyPageContent로 이동했습니다.
export default 하는 VerifyPage 컴포넌트에서 ClientVerifyPageContent를 <Suspense fallback={<div>페이지를 로딩 중입니다...</div>}>로 감싸도록 수정했습니다.
이 변경으로 인해 next build 시 사전 렌더링 단계에서 useSearchParams()가 포함된 컴포넌트가 동적으로 처리되어 빌드 오류 없이 성공적으로 정적 페이지가 생성됩니다. 사용자 경험 측면에서는 페이지 로딩 시 잠시 fallback 콘텐츠(예: "페이지를 로딩 중입니다...")가 표시될 수 있지만, 대부분의 경우 빠르게 하이드레이션되어 정상적인 콘텐츠가 나타납니다.

✅ 검증
로컬 환경에서 npm run build 명령을 통해 성공적으로 빌드가 완료되었음을 확인했습니다.
Netlify 환경에서도 정상적으로 배포될 것으로 예상됩니다.