### PR TITLE
Fix: 백엔드 HTTPS 미지원 대응을 위한 Netlify 프록시 설정 및 API 요청 경로 수정

### DIFF
--- a/src/frontend/netlify.toml
+++ b/src/frontend/netlify.toml
@@ -13,4 +13,9 @@ NEXT_PUBLIC_API_URL = "http://13.125.255.84"
 [[plugins]]
 package = "@netlify/plugin-nextjs"
 
+[[redirects]]
+from = "/api/*"
+to = "http://13.125.255.84:80/:splat"
+status = 200
+force = true
 

--- a/src/frontend/src/app/camera/page.tsx
+++ b/src/frontend/src/app/camera/page.tsx
@@ -80,7 +80,7 @@ const CameraScreen: React.FC = () => {
     formData.append('content', '캡처한 이미지');
 
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/receipt/process`, {
+      const response = await fetch(`/api/receipt/process`, {
         method: 'POST',
         body: formData,
       });

--- a/src/frontend/src/app/community/vote/page.tsx
+++ b/src/frontend/src/app/community/vote/page.tsx
@@ -49,7 +49,7 @@ export default function VotePage() {
   ]
   useEffect(() => {
     if (activeTab === 'vote') {
-      fetch(`${process.env.NEXT_PUBLIC_API_URL}/proposals/user/1`) 
+      fetch(`/api/proposals/user/1`) 
         .then(res => res.json())
         .then(data => {
           console.log('fetch proposals:', data);

--- a/src/frontend/src/app/donation/detail/firefighter/page.tsx
+++ b/src/frontend/src/app/donation/detail/firefighter/page.tsx
@@ -37,7 +37,7 @@ export default function DonationDetailPage() {
   // 포인트 차감 로직
   const handleDonate = async (amount: number) => {
     const userId = 1; // 실제 로그인된 유저 ID로 교체
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/${userId}/donate`, {
+      const res = await fetch(`/api/users/${userId}/donate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ amount }),

--- a/src/frontend/src/app/donation/detail/firevictims/page.tsx
+++ b/src/frontend/src/app/donation/detail/firevictims/page.tsx
@@ -36,7 +36,7 @@ export default function DonationDetailPage() {
   // 포인트 차감 로직
   const handleDonate = async (amount: number) => {
     const userId = 1; // 실제 로그인된 유저 ID로 교체
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/${userId}/donate`, {
+      const res = await fetch(`/api/users/${userId}/donate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ amount }),

--- a/src/frontend/src/app/donation/detail/msf/page.tsx
+++ b/src/frontend/src/app/donation/detail/msf/page.tsx
@@ -36,7 +36,7 @@ export default function DonationDetailPage() {
   // 포인트 차감 로직
   const handleDonate = async (amount: number) => {
     const userId = 1; // 실제 로그인된 유저 ID로 교체
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/${userId}/donate`, {
+      const res = await fetch(`/api/users/${userId}/donate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ amount }),

--- a/src/frontend/src/app/donation/page.tsx
+++ b/src/frontend/src/app/donation/page.tsx
@@ -28,7 +28,7 @@ export default function DonationPage() {
   }, [stage]);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/1/points`)
+    fetch(`/api/users/1/points`)
       .then(res => res.json())
       .then(data => {
         const pt = data.points;
@@ -89,7 +89,7 @@ export default function DonationPage() {
 
     const delta = 10;
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/1/points`, {
+      const res = await fetch(`/api/users/1/points`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ delta }),

--- a/src/frontend/src/app/login/page.tsx
+++ b/src/frontend/src/app/login/page.tsx
@@ -16,7 +16,7 @@ export default function Login() {
     console.log("API 주소 확인:", process.env.NEXT_PUBLIC_API_URL);
     
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/login`, {
+      const res = await fetch(`/api/users/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/frontend/src/app/map/page.tsx
+++ b/src/frontend/src/app/map/page.tsx
@@ -34,7 +34,7 @@ export default function MapPage() {
 
   // 1️⃣ 서버에서 착한가게 전체 데이터 받아오기
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/stores`)
+    fetch(`/api/stores`)
       .then(res => res.json())
       .then(setStores)
       .catch(() => setStores([]));

--- a/src/frontend/src/app/mypage/page.tsx
+++ b/src/frontend/src/app/mypage/page.tsx
@@ -15,7 +15,7 @@ export default function MyPage() {
   // 닉네임 요청
   useEffect(() => {
     // (예시) /api/my/nickname 엔드포인트에서 닉네임을 가져온다고 가정
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/my/nickname`, {
+    fetch(`/api/my/nickname`, {
       method: 'GET',
       // credentials, headers 등 실제 인증 필요 시 추가
     })

--- a/src/frontend/src/app/mypage_history/page.tsx
+++ b/src/frontend/src/app/mypage_history/page.tsx
@@ -63,13 +63,13 @@ export default function HistoryPage() {
 
   useEffect(() => {
   // 닉네임 불러오기
-  fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/my/nickname`, { method: 'GET',// credentials, headers 등 실제 인증추가
+  fetch(`/api/my/nickname`, { method: 'GET',// credentials, headers 등 실제 인증추가
     })
     .then(res => res.json())
     .then(data => setNickname(data.nickname));
 
     // 리뷰 내역 가져오기
-  fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/reviews/user/${userId}`)
+  fetch(`/api/reviews/user/${userId}`)
     .then(res => res.json())
     .then(data => {
       const mapped = data.map((r: any) => ({
@@ -84,7 +84,7 @@ export default function HistoryPage() {
     });
 
   // 제보 내역 가져오기
-  fetch(`${process.env.NEXT_PUBLIC_API_URL}/proposals/user/${userId}`)
+  fetch(`/api/proposals/user/${userId}`)
     .then(res => res.json())
     .then(data => {
       const mapped = data.map((p: any) => ({

--- a/src/frontend/src/app/nearby_donjjul/page.tsx
+++ b/src/frontend/src/app/nearby_donjjul/page.tsx
@@ -51,7 +51,7 @@ export default function NearbyDonjjul() {
           <div key={store.id} className="flex items-center mb-4">
             <div className="w-[70px] h-[70px] relative flex-shrink-0 rounded-lg overflow-hidden">
               <Image
-                src={`${process.env.NEXT_PUBLIC_API_URL}s/images/${store.image}`}
+                src={`/api/images/${store.image}`}
                 alt={store.name}
                 fill
                 className="object-cover"

--- a/src/frontend/src/app/nearby_new/page.tsx
+++ b/src/frontend/src/app/nearby_new/page.tsx
@@ -29,7 +29,7 @@ export default function NearbyDonjjul() {
   const router = useRouter()
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/stores/top12`)
+    fetch(`/api/stores/top12`)
       .then((res) => res.json())
       .then((data) => setStores(data))
       .catch((err) => {
@@ -51,7 +51,7 @@ export default function NearbyDonjjul() {
           <div key={store.id} className="flex items-center mb-4">
             <div className="w-[70px] h-[70px] relative flex-shrink-0 rounded-lg overflow-hidden">
               <Image
-                src={`${process.env.NEXT_PUBLIC_API_URL}/images/${store.image}`}
+                src={`/api/images/${store.image}`}
                 alt={store.name}
                 fill
                 className="object-cover"

--- a/src/frontend/src/app/review/page.tsx
+++ b/src/frontend/src/app/review/page.tsx
@@ -36,7 +36,7 @@ function ReviewPageContent() {
       setLoading(false); // businessNumber가 없으면 로딩 종료
       return;
     }
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/stores/${businessNumber}`)
+    fetch(`/api/stores/${businessNumber}`)
       .then(res => res.ok ? res.json() : Promise.reject('가게 정보 없음'))
       .then(data => {
         setStore(data);
@@ -58,7 +58,7 @@ function ReviewPageContent() {
     const payload = { userId, storeId, rating, content: review };
 
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/reviews`, {
+      const res = await fetch(`/api/reviews`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
@@ -87,7 +87,7 @@ function ReviewPageContent() {
           {/* 이미지 + 닫기 */}
           <div className="w-full h-40 rounded-xl overflow-hidden mb-4 relative">
             {store.image ? (
-              <Image src={`${process.env.NEXT_PUBLIC_API_URL}/images/${store.image}`} alt="가게 이미지" fill unoptimized className="object-cover" />
+              <Image src={`/api/images/${store.image}`} alt="가게 이미지" fill unoptimized className="object-cover" />
             ) : (
               <div className="w-full h-full bg-gray-200 flex items-center justify-center">이미지 없음</div>
             )}

--- a/src/frontend/src/app/signup/page.tsx
+++ b/src/frontend/src/app/signup/page.tsx
@@ -23,7 +23,7 @@ export default function SignUpPage() {
     };
 
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users`, {
+      const response = await fetch(`/api/users`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/src/frontend/src/app/store/[id]/page.tsx
+++ b/src/frontend/src/app/store/[id]/page.tsx
@@ -67,14 +67,14 @@ export default function Store() {
 // ]
   useEffect(() => {
     if (!id) return
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/stores/store/${id}`)  // ✅ 백엔드에서 id 기반 상세정보 요청
+    fetch(`/api/stores/store/${id}`)  // ✅ 백엔드에서 id 기반 상세정보 요청
       .then((res) => res.json())
       .then((data) => setStore(data))
       .catch((err) => console.error('상세정보 요청 실패:', err))
 
 
     // 리뷰 리스트 가져오기
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/reviews/store/${id}`)
+    fetch(`/api/reviews/store/${id}`)
       .then((res) => res.json())
       .then((data: Review[]) => setReviews(data))
       .catch((err) => {
@@ -93,7 +93,7 @@ export default function Store() {
         <div className="bg-white rounded-[40px] w-full max-w-md p-4 pb-20 shadow-md relative">
           {/* 이미지 + 닫기 */}
           <div className="w-full h-40 rounded-xl overflow-hidden mb-4 relative">
-            <Image src={`${process.env.NEXT_PUBLIC_API_URL}/images/${store.image}`} alt={store.name} fill className="object-cover" />
+            <Image src={`/api/images/${store.image}`} alt={store.name} fill className="object-cover" />
             <button
               onClick={() => router.back()}
               className="absolute top-2 right-2 bg-black/40 text-white w-8 h-8 rounded-full flex items-center justify-center"

--- a/src/frontend/src/app/submit_store/page.tsx
+++ b/src/frontend/src/app/submit_store/page.tsx
@@ -37,7 +37,7 @@ function VerifyPageContent() {
   console.log('payload:', payload);
 
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/proposals`, {
+    const res = await fetch(`/api/proposals`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/src/frontend/src/components/NearbySection.tsx
+++ b/src/frontend/src/components/NearbySection.tsx
@@ -20,11 +20,11 @@ export default function NearbySection() {
   const router = useRouter()
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/stores/top6`)  // 백엔드 구현 필요
+    fetch(`/api/stores/top6`)  // 백엔드 구현 필요
       .then(res => res.json())
       .then(setNearbyStores)
 
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/stores/top12`)      // 백엔드 구현 필요
+    fetch(`/api/stores/top12`)      // 백엔드 구현 필요
       .then(res => res.json())
       .then(setNewStores)
   }, [])
@@ -79,7 +79,7 @@ function StoreCard({ store, router }: { store: Store; router: any }) {
     <div className="flex items-center mb-4">
       <div className="w-[70px] h-[70px] relative rounded-lg overflow-hidden">
         <Image
-          src={`${process.env.NEXT_PUBLIC_API_URL}/images/${store.image}`}
+          src={`/api/images/${store.image}`}
           alt={store.name}
           fill
           className="object-cover"

--- a/src/frontend/src/components/modals/DonationModal.tsx
+++ b/src/frontend/src/components/modals/DonationModal.tsx
@@ -23,7 +23,7 @@ export default function DonationModal({ isOpen, onClose, onDonate }: DonationMod
   useEffect(() => {
     if (isOpen) {
       const userId = 1;
-      fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/${userId}/points`)
+      fetch(`/api/users/${userId}/points`)
         .then(res => res.json())
         .then(data => setUserPoints(data.points))
         .catch(() => setUserPoints(0));


### PR DESCRIPTION
## 📌 개요
- 백엔드 서버(EC2)에서 HTTPS 설정이 불가능하다는 동료 측 피드백에 따라, 
  Netlify 프록시 기능을 통해 HTTPS 환경에서도 브라우저의 Mixed Content 정책을 우회하도록 수정하였습니다.

## 🔧 주요 변경 사항
1. `netlify.toml`에 프록시 리디렉션 설정 추가
   ```toml
   [[redirects]]
   from = "/api/*"
   to = "http://13.125.255.84:80/:splat"
   status = 200
   force = true

2. 모든 fetch() 요청 경로를 /api/... 형식으로 통일

기존: fetch(${process.env.NEXT_PUBLIC_API_URL}/users/login)

변경: fetch("/api/users/login")

NEXT_PUBLIC_API_URL 환경변수 더 이상 사용하지 않음 → 관련 코드 제거

.env 내 NEXT_PUBLIC_API_URL 제거